### PR TITLE
Add mongo delete contracts to mongoapi

### DIFF
--- a/mongoapi/src/main/java/in/mtap/iincube/mongoapi/MongoClient.java
+++ b/mongoapi/src/main/java/in/mtap/iincube/mongoapi/MongoClient.java
@@ -44,7 +44,7 @@ public final class MongoClient implements DocumentClient, FsClient, SuperDocumen
    * <p>
    * Note: Does not performs connect
    *
-   * @see {@link #MongoClient(com.mongodb.MongoClient)}
+   * @see #MongoClient(com.mongodb.MongoClient)
    */
   public MongoClient(com.mongodb.MongoClient mongoClient) {
     this.mongo = mongoClient;

--- a/mongoapi/src/main/java/in/mtap/iincube/mongoapi/MongoClient.java
+++ b/mongoapi/src/main/java/in/mtap/iincube/mongoapi/MongoClient.java
@@ -22,21 +22,32 @@ import com.mongodb.gridfs.GridFSDBFile;
 
 /**
  * A wrapper class for Mongo client java driver.
- *<p>
+ * <p>
  * For MongoDB read request the api uses {@link DBObjectEncoder} to encode each cursor result.
  * For example getting the result in json
  */
-public final class MongoClient implements DocumentClient, FsClient {
+public final class MongoClient implements DocumentClient, FsClient, SuperDocumentClient {
 
   private final Mongo mongo;
+
+  /**
+   * Will be removed in next major release
+   *
+   * Instead use {@link #MongoClient(com.mongodb.MongoClient)}
+   */
+  @Deprecated public MongoClient(Mongo mongo) {
+    this.mongo = mongo;
+  }
 
   /**
    * Accepts {@link Mongo} object that is already connected to the mongo server.
    * <p>
    * Note: Does not performs connect
+   *
+   * @see {@link #MongoClient(com.mongodb.MongoClient)}
    */
-  public MongoClient(Mongo mongo) {
-    this.mongo = mongo;
+  public MongoClient(com.mongodb.MongoClient mongoClient) {
+    this.mongo = mongoClient;
   }
 
   @Override public MongoReader read(String dbname, String colname) {
@@ -49,6 +60,10 @@ public final class MongoClient implements DocumentClient, FsClient {
 
   @Override public MongoWriter write(String dbname, String colname) {
     return new MongoWriter(new MongoCollectionFactory(mongo, dbname, colname));
+  }
+
+  @Override public MongoDeleter remover(String dbname, String colname) {
+    return new MongoDeleter(new MongoCollectionFactory(mongo, dbname, colname));
   }
 
   @Override public GridFsRequestBuilder<Boolean> gridFsUpdate(String dbname, String bucketname) {

--- a/mongoapi/src/main/java/in/mtap/iincube/mongoapi/MongoDeleter.java
+++ b/mongoapi/src/main/java/in/mtap/iincube/mongoapi/MongoDeleter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 mtap technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package in.mtap.iincube.mongoapi;
+
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.WriteResult;
+
+public class MongoDeleter {
+  private final MongoObjectFactory<DBCollection> collectionFactory;
+  private DBObject dbObject;
+
+  MongoDeleter(MongoObjectFactory<DBCollection> collectionFactory) {
+    this.collectionFactory = collectionFactory;
+  }
+
+  MongoDeleter find(DBObject dbObject) {
+    this.dbObject = dbObject;
+    return this;
+  }
+
+  WriteResult execute() {
+    return collectionFactory.get().remove(dbObject);
+  }
+
+  /** @return the dbobject the of the document that is deleted */
+  DBObject findAndRemove(DBObject dbObject) {
+    return collectionFactory.get().findAndRemove(dbObject);
+  }
+}

--- a/mongoapi/src/main/java/in/mtap/iincube/mongoapi/SuperDocumentClient.java
+++ b/mongoapi/src/main/java/in/mtap/iincube/mongoapi/SuperDocumentClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,16 +17,7 @@
 
 package in.mtap.iincube.mongoapi;
 
-import com.mongodb.Mongo;
-
-class GridFsUpdater extends GridFsRequestBuilder<Boolean> {
-
-  GridFsUpdater(Mongo mongo, String dbname, String bucketname) {
-    super(mongo, dbname, bucketname);
-  }
-
-  @Override public Boolean execute() {
-
-    return false;
-  }
+/** Same as {@link DocumentClient} with an additional delete contract */
+public interface SuperDocumentClient extends DocumentClient {
+  MongoDeleter remover(String dbname, String colname);
 }


### PR DESCRIPTION
Feeling bad on the naming `SuperDocumentClient` will find a better name in the next iteration. Thinking of releasing this with `rc` flag.
